### PR TITLE
luup.set_failure and HWADDR

### DIFF
--- a/L_SmartMeterHAN1.lua
+++ b/L_SmartMeterHAN1.lua
@@ -1,6 +1,6 @@
 -- Plugin for the Rainforest Eagle 100/200
 --
--- Copyright (c) 2017-2018 John Schmitz
+-- Copyright (c) 2017-2019 John Schmitz
 
 -- Permission is hereby granted, free of charge, to any person obtaining a copy
 -- of this software and associated documentation files (the "Software"), to deal

--- a/L_SmartMeterHAN1.lua
+++ b/L_SmartMeterHAN1.lua
@@ -436,6 +436,7 @@ function startup(han_device)
         log("Eagle 200: xmlstring is: " .. xmlstring, 1)
         return false, "Cannot find hardware address", "SmartMeterHAN1"
       else
+        setVar("HAN_HWADDR", HAN_HWADDR)
         log("Eagle 200: Found hardware address: " .. HAN_HWADDR, 3)
       end
       if connectionStatus then


### PR DESCRIPTION
Only get HWADDR from Eagle 200 the first time and store it in a device variable.  Later can use the stored value.  Works around the many luup restarts and the fact that once in a while the Eagle returns an empty string on the device_list command.

Also stop using luup.set_failure on UI7.  Not sure why but users report issues and I have no way to debug or test.